### PR TITLE
Include lib64/site-packages path in lambda zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,5 @@ virtualenv:
 
 zip: clean virtualenv
 	zip lambda.zip aws_lambda/sign_xpi.py aws_lambda/__init__.py
-	cd venv/lib/python2.7/site-packages/; zip -r ../../../../lambda.zip *
+	pushd venv/lib/python2.7/site-packages/; zip -r ../../../../lambda.zip *; popd
+	pushd venv/lib64/python2.7/site-packages/; zip -r ../../../../lambda.zip *; popd


### PR DESCRIPTION
M2Crypto is installed in the lib64 path and we need to include it as part of the lambda.zip. Fixes `Unable to import module 'aws_lambda.sign_xpi': No module named M2Crypto`