### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazonlinux:latest
+
+COPY . /app
+WORKDIR /app
+
+RUN yum install -y python27-virtualenv openssl-devel zip
+RUN make zip

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,11 @@ zip: clean virtualenv
 	zip lambda.zip aws_lambda/sign_xpi.py aws_lambda/__init__.py
 	pushd venv/lib/python2.7/site-packages/; zip -r ../../../../lambda.zip *; popd
 	pushd venv/lib64/python2.7/site-packages/; zip -r ../../../../lambda.zip *; popd
+
+build_image:
+	docker build -t sign-xpi .
+
+get_zip: build_image
+	docker rm sign-xpi || true
+	docker run --name sign-xpi sign-xpi
+	docker cp sign-xpi:/app/lambda.zip .


### PR DESCRIPTION
We need to build M2Crypto in amazon linux environment to work correctly with lambda. The Dockerfile uses a amazonlinux base image to achieve this build environment. I've added a few additional commands to the Makefile as well so that we can use to build the image and get the zip artifact from the container.

r?