### PR TITLE
Add gcc dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM amazonlinux:latest
 COPY . /app
 WORKDIR /app
 
-RUN yum install -y python27-virtualenv openssl-devel zip
+RUN yum install -y python27-virtualenv openssl-devel zip gcc
 RUN make zip


### PR DESCRIPTION
I am not sure how I missed this but it is needed to build M2Crypto.