### PR TITLE
Add S3 events and prefix verification

### DIFF
--- a/aws_lambda/sign_xpi.py
+++ b/aws_lambda/sign_xpi.py
@@ -74,6 +74,28 @@ class SourceInfo(marshmallow.Schema):
             ["url", "bucket", "key"])
 
 
+class BucketData(marshmallow.Schema):
+    name = marshmallow.fields.String(required=True)
+
+
+class ObjectData(marshmallow.Schema):
+    key = marshmallow.fields.String(required=True)
+
+
+class S3Data(marshmallow.Schema):
+    bucket = marshmallow.fields.Nested(BucketData, required=True)
+    object = marshmallow.fields.Nested(ObjectData, required=True)
+
+
+class EventRecord(marshmallow.Schema):
+    s3 = marshmallow.fields.Nested(S3Data, required=True)
+
+
+class S3Event(marshmallow.Schema):
+    records = marshmallow.fields.List(
+        marshmallow.fields.Nested(EventRecord), load_from='Records', required=True)
+
+
 class SignEvent(marshmallow.Schema):
     source = marshmallow.fields.Nested(SourceInfo, required=True)
     checksum = marshmallow.fields.String()

--- a/aws_lambda/sign_xpi.py
+++ b/aws_lambda/sign_xpi.py
@@ -197,7 +197,7 @@ def compute_checksum(contents):
 
 
 def get_guid(xpi_file):
-    ext_id = get_extension_id(xpi_file)
+    ext_id = get_extension_id(zipfile.ZipFile(xpi_file))
     if len(ext_id) <= 64:
         return ext_id
     return hashlib.sha256(ext_id).hexdigest()
@@ -212,13 +212,12 @@ def verify_extension_id(event, xpi_id):
         raise S3IdMatchError(xpi_id, event_id)
 
 
-def get_extension_id(xpi_file):
-    zip = zipfile.ZipFile(xpi_file)
-    contents = zip.namelist()
+def get_extension_id(zipfile):
+    contents = zipfile.namelist()
     if 'install.rdf' in contents:
-        return get_extension_id_rdf(zip.open('install.rdf'))
+        return get_extension_id_rdf(zipfile.open('install.rdf'))
     elif 'manifest.json' in contents:
-        return get_extension_id_json(zip.open('manifest.json'))
+        return get_extension_id_json(zipfile.open('manifest.json'))
 
     raise ValueError("Extension is missing a manifest")
 

--- a/tests/test_aws_lambda.py
+++ b/tests/test_aws_lambda.py
@@ -117,3 +117,20 @@ def test_parse_s3_event_fails_when_missing_s3():
     }
     with pytest.raises(marshmallow.exceptions.ValidationError):
         sign_xpi.S3Event(strict=True).load(raw_s3_event).data
+
+
+def test_verify_extension_id_sanity_check():
+    event = {'s3': {'object': {'key': 'test-pilot@mozilla.com/build-20170715.xpi'}}}
+    sign_xpi.verify_extension_id(event, 'test-pilot@mozilla.com')
+
+
+def test_verify_extension_id_enforces_match():
+    event = {'s3': {'object': {'key': 'devtools@mozilla.com/build-20170715.xpi'}}}
+    with pytest.raises(sign_xpi.S3IdMatchError):
+        sign_xpi.verify_extension_id(event, 'test-pilot@mozilla.com')
+
+
+def test_verify_extension_id_handles_missing_id():
+    event = {'s3': {'object': {'key': 'build-20170715.xpi'}}}
+    with pytest.raises(sign_xpi.S3IdNotPresentError):
+        sign_xpi.verify_extension_id(event, 'test-pilot@mozilla.com')

--- a/tests/test_aws_lambda.py
+++ b/tests/test_aws_lambda.py
@@ -1,4 +1,5 @@
 import io
+from unittest import mock
 import pytest
 import marshmallow.exceptions
 from aws_lambda import sign_xpi
@@ -134,3 +135,23 @@ def test_verify_extension_id_handles_missing_id():
     event = {'s3': {'object': {'key': 'build-20170715.xpi'}}}
     with pytest.raises(sign_xpi.S3IdNotPresentError):
         sign_xpi.verify_extension_id(event, 'test-pilot@mozilla.com')
+
+
+def test_get_extension_id_invokes_rdf():
+    """Verify that get_extension_id tries to determine the XPI type"""
+    zip = mock.Mock()
+    zip.namelist = mock.Mock(return_value=['install.rdf'])
+    id_sentinel = mock.sentinel.rdf_id
+    with mock.patch('aws_lambda.sign_xpi.get_extension_id_rdf',
+                    return_value=id_sentinel):
+        assert sign_xpi.get_extension_id(zip) == id_sentinel
+
+
+def test_get_extension_id_invokes_json():
+    """Verify that get_extension_id tries to determine the XPI type"""
+    zip = mock.Mock()
+    zip.namelist = mock.Mock(return_value=['manifest.json'])
+    id_sentinel = mock.sentinel.json_id
+    with mock.patch('aws_lambda.sign_xpi.get_extension_id_json',
+                    return_value=id_sentinel):
+        assert sign_xpi.get_extension_id(zip) == id_sentinel

--- a/tests/test_aws_lambda.py
+++ b/tests/test_aws_lambda.py
@@ -1,4 +1,6 @@
 import io
+import pytest
+import marshmallow.exceptions
 from aws_lambda import sign_xpi
 
 
@@ -14,3 +16,104 @@ def test_get_extension_id_rdf_sanity_check():
     extension_id = sign_xpi.get_extension_id_rdf(simple_rdf)
 
     assert extension_id == 'hypothetical-addon@mozilla.org'
+
+
+def test_parse_s3_event_success():
+    raw_s3_event = {
+        "Records": [
+            {
+                "eventVersion":"2.0",
+                "eventSource":"aws:s3",
+                "awsRegion":"us-east-1",
+                "eventTime": "1970-01-01T00:00:00.000Z",
+                "eventName":"ObjectCreated:Put",
+                "userIdentity":{
+                    "principalId":"Amazon-customer-ID-of-the-user-who-caused-the-event"
+                },
+                "requestParameters":{
+                    "sourceIPAddress":"ip-address-where-request-came-from"
+                },
+                "responseElements":{
+                    "x-amz-request-id":"Amazon S3 generated request ID",
+                    "x-amz-id-2":"Amazon S3 host that processed the request"
+                },
+                "s3":{
+                    "s3SchemaVersion":"1.0",
+                    "configurationId":"ID found in the bucket notification configuration",
+                    "bucket":{
+                        "name":"mybucket",
+                        "ownerIdentity":{
+                            "principalId":"Amazon-customer-ID-of-the-bucket-owner"
+                        },
+                        "arn":"bucket-ARN"
+                    },
+                    "object":{
+                        "key":"HappyFace.jpg",
+                        "size":1024,
+                        "eTag":"d41d8cd98f00b204e9800998ecf8427e",
+                        "versionId":"096fKKXTRTtl3on89fVO.nfljtsv6qko",
+                        "sequencer":"0055AED6DCD90281E5"
+                    }
+                }
+            },
+        ]
+    }
+    s3_event = sign_xpi.S3Event(strict=True).load(raw_s3_event).data
+    assert s3_event == {
+        'records': [
+            {
+                's3': {
+                    'bucket': {
+                        'name': 'mybucket',
+                    },
+                    'object': {
+                        'key': 'HappyFace.jpg',
+                    }
+                }
+            }
+        ]
+    }
+
+
+def test_parse_s3_event_fails_when_missing_s3():
+    raw_s3_event = {
+        "Records": [
+            {
+                "eventVersion":"2.0",
+                "eventSource":"aws:s3",
+                "awsRegion":"us-east-1",
+                "eventTime": "1970-01-01T00:00:00.000Z",
+                "eventName":"ObjectCreated:Put",
+                "userIdentity":{
+                    "principalId":"Amazon-customer-ID-of-the-user-who-caused-the-event"
+                },
+                "requestParameters":{
+                    "sourceIPAddress":"ip-address-where-request-came-from"
+                },
+                "responseElements":{
+                    "x-amz-request-id":"Amazon S3 generated request ID",
+                    "x-amz-id-2":"Amazon S3 host that processed the request"
+                },
+                "s4":{
+                    "s3SchemaVersion":"1.0",
+                    "configurationId":"ID found in the bucket notification configuration",
+                    "bucket":{
+                        "name":"mybucket",
+                        "ownerIdentity":{
+                            "principalId":"Amazon-customer-ID-of-the-bucket-owner"
+                        },
+                        "arn":"bucket-ARN"
+                    },
+                    "object":{
+                        "key":"HappyFace.jpg",
+                        "size":1024,
+                        "eTag":"d41d8cd98f00b204e9800998ecf8427e",
+                        "versionId":"096fKKXTRTtl3on89fVO.nfljtsv6qko",
+                        "sequencer":"0055AED6DCD90281E5"
+                    }
+                }
+            },
+        ]
+    }
+    with pytest.raises(marshmallow.exceptions.ValidationError):
+        sign_xpi.S3Event(strict=True).load(raw_s3_event).data


### PR DESCRIPTION
As discussed with @jvehent and @jasonthomas, we're going to make this lambda listen to S3 events, which will be the only way to invoke it, and we'll slice up the S3 bucket using the extension ID as a "prefix". This PR adds support for S3 events and verifies that the extension ID matches the S3 path.

- [ ] Test in dev

r? @Natim 